### PR TITLE
DBInterface accessor for a given DB connection handle.

### DIFF
--- a/db.go
+++ b/db.go
@@ -35,6 +35,11 @@ func NewDBFromInterface(db DBInterface, dialect Dialect, logger Logger) *DB {
 	}
 }
 
+// DBInterface returns DBInterface associated with a given DB object.
+func (db *DB) DBInterface() DBInterface {
+	return db.db
+}
+
 // Begin starts a transaction.
 func (db *DB) Begin() (*TX, error) {
 	db.logBefore("BEGIN", nil)


### PR DESCRIPTION
I think it's better to provide accessor for DBInterface instead of sql.DB since it's is more generic and logical. So it's up to user to make type assertion to get sql.DB.