### PR TITLE
Add MariaDB to CI configuration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,11 +26,11 @@ jobs:
           - 1.17.x
           - tip
         images:
-          - { postgres: "postgres:9.5", mariadb: "10.2", mysql: "mysql:5.6", mssql: "mcr.microsoft.com/mssql/server:2017-latest" }
-          - { postgres: "postgres:9.6", mariadb: "10.3", mysql: "mysql:5.7", mssql: "mcr.microsoft.com/mssql/server:2019-latest" }
-          - { postgres: "postgres:10", mariadb: "10.4", mysql: "mysql:8.0" }
-          - { postgres: "postgres:11", mariadb: "10.5" }
-          - { postgres: "postgres:12", mariadb: "10.6" }
+          - { postgres: "postgres:9.5", mariadb: "mariadb:10.2", mysql: "mysql:5.6", mssql: "mcr.microsoft.com/mssql/server:2017-latest" }
+          - { postgres: "postgres:9.6", mariadb: "mariadb:10.3", mysql: "mysql:5.7", mssql: "mcr.microsoft.com/mssql/server:2019-latest" }
+          - { postgres: "postgres:10", mariadb: "mariadb:10.4", mysql: "mysql:8.0" }
+          - { postgres: "postgres:11", mariadb: "mariadb:10.5" }
+          - { postgres: "postgres:12", mariadb: "mariadb:10.6" }
           - { postgres: "postgres:13" }
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,11 +26,11 @@ jobs:
           - 1.17.x
           - tip
         images:
-          - { postgres: "postgres:9.5", mysql: "mysql:5.6", mssql: "mcr.microsoft.com/mssql/server:2017-latest" }
-          - { postgres: "postgres:9.6", mysql: "mysql:5.7", mssql: "mcr.microsoft.com/mssql/server:2019-latest" }
-          - { postgres: "postgres:10",  mysql: "mysql:8.0" }
-          - { postgres: "postgres:11" }
-          - { postgres: "postgres:12" }
+          - { postgres: "postgres:9.5", mariadb: "10.2", mysql: "mysql:5.6", mssql: "mcr.microsoft.com/mssql/server:2017-latest" }
+          - { postgres: "postgres:9.6", mariadb: "10.3", mysql: "mysql:5.7", mssql: "mcr.microsoft.com/mssql/server:2019-latest" }
+          - { postgres: "postgres:10", mariadb: "10.4", mysql: "mysql:8.0" }
+          - { postgres: "postgres:11", mariadb: "10.5" }
+          - { postgres: "postgres:12", mariadb: "10.6" }
           - { postgres: "postgres:13" }
 
     runs-on: ${{ matrix.os }}
@@ -45,6 +45,7 @@ jobs:
       GOPROXY: "https://proxy.golang.org"
       GORACE: "halt_on_error=1"
       REFORM_POSTGRES_IMAGE: "${{ matrix.images.postgres }}"
+      REFORM_MARIADB_IMAGE: "${{ matrix.images.mariadb }}"
       REFORM_MYSQL_IMAGE: "${{ matrix.images.mysql }}"
       REFORM_MSSQL_IMAGE: "${{ matrix.images.mssql }}"
 
@@ -133,7 +134,7 @@ jobs:
 
       - name: Upload coverage information
         working-directory: ${{ env.WORKDIR }}
-        run: bash <(curl -s https://codecov.io/bash) -f coverage.txt -X fix -e GO_VERSION,REFORM_POSTGRES_IMAGE,REFORM_MYSQL_IMAGE,REFORM_MSSQL_IMAGE
+        run: bash <(curl -s https://codecov.io/bash) -f coverage.txt -X fix -e GO_VERSION,REFORM_POSTGRES_IMAGE,REFORM_MARIADB_IMAGE,REFORM_MYSQL_IMAGE,REFORM_MSSQL_IMAGE
 
       - name: Run debug commands on failure
         if: ${{ failure() }}
@@ -173,6 +174,7 @@ jobs:
       GOPROXY: "https://proxy.golang.org"
       GORACE: "halt_on_error=1"
       REFORM_POSTGRES_IMAGE: "${{ matrix.images.postgres }}"
+      REFORM_MARIADB_IMAGE: "${{ matrix.images.mariadb }}"
       REFORM_MYSQL_IMAGE: "${{ matrix.images.mysql }}"
       REFORM_MSSQL_IMAGE: "${{ matrix.images.mssql }}"
 

--- a/Makefile
+++ b/Makefile
@@ -110,16 +110,6 @@ pgx: export REFORM_TEST_COVER=pgx
 pgx:
 	make test-db
 
-# run integration tests for MariaDB (traditional SQL mode + interpolateParams)
-mariadb-traditional: export REFORM_TEST_DATABASE = mysql
-mariadb-traditional: export REFORM_TEST_DRIVER = mysql
-mariadb-traditional: export REFORM_TEST_ADMIN_SOURCE = root@tcp(localhost:6033)/mysql
-mariadb-traditional: export REFORM_TEST_INIT_SOURCE = root@tcp(localhost:6033)/reform-database?parseTime=true&clientFoundRows=true&time_zone='UTC'&sql_mode='ANSI'&multiStatements=true
-mariadb-traditional: export REFORM_TEST_SOURCE = root@tcp(localhost:6033)/reform-database?parseTime=true&clientFoundRows=true&time_zone='America%2FNew_York'&sql_mode='TRADITIONAL'&interpolateParams=true
-mariadb-traditional: export REFORM_TEST_COVER=mysql
-mariadb-traditional:
-	make test-db
-
 # run integration tests for MariaDB (ANSI SQL mode)
 mariadb: export REFORM_TEST_DATABASE = mysql
 mariadb: export REFORM_TEST_DRIVER = mysql
@@ -130,14 +120,14 @@ mariadb: export REFORM_TEST_COVER=mysql
 mariadb:
 	make test-db
 
-# run integration tests for MySQL (traditional SQL mode + interpolateParams)
-mysql-traditional: export REFORM_TEST_DATABASE = mysql
-mysql-traditional: export REFORM_TEST_DRIVER = mysql
-mysql-traditional: export REFORM_TEST_ADMIN_SOURCE = root@/mysql
-mysql-traditional: export REFORM_TEST_INIT_SOURCE = root@/reform-database?parseTime=true&clientFoundRows=true&time_zone='UTC'&sql_mode='ANSI'&multiStatements=true
-mysql-traditional: export REFORM_TEST_SOURCE = root@/reform-database?parseTime=true&clientFoundRows=true&time_zone='America%2FNew_York'&sql_mode='TRADITIONAL'&interpolateParams=true
-mysql-traditional: export REFORM_TEST_COVER=mysql-traditional
-mysql-traditional:
+# run integration tests for MariaDB (traditional SQL mode + interpolateParams)
+mariadb-traditional: export REFORM_TEST_DATABASE = mysql
+mariadb-traditional: export REFORM_TEST_DRIVER = mysql
+mariadb-traditional: export REFORM_TEST_ADMIN_SOURCE = root@tcp(localhost:6033)/mysql
+mariadb-traditional: export REFORM_TEST_INIT_SOURCE = root@tcp(localhost:6033)/reform-database?parseTime=true&clientFoundRows=true&time_zone='UTC'&sql_mode='ANSI'&multiStatements=true
+mariadb-traditional: export REFORM_TEST_SOURCE = root@tcp(localhost:6033)/reform-database?parseTime=true&clientFoundRows=true&time_zone='America%2FNew_York'&sql_mode='TRADITIONAL'&interpolateParams=true
+mariadb-traditional: export REFORM_TEST_COVER=mysql
+mariadb-traditional:
 	make test-db
 
 # run integration tests for MySQL (ANSI SQL mode)

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,8 @@ test:                                    ## Run all tests and gather coverage.
 
 	make postgres
 	make pgx
+	make mariadb
+	make mariadb-traditional
 	make mysql
 	make mysql-traditional
 	make sqlite3
@@ -106,6 +108,36 @@ pgx: export REFORM_TEST_INIT_SOURCE = postgres://postgres@127.0.0.1/reform-datab
 pgx: export REFORM_TEST_SOURCE = postgres://postgres@127.0.0.1/reform-database?sslmode=disable&TimeZone=America/New_York
 pgx: export REFORM_TEST_COVER=pgx
 pgx:
+	make test-db
+
+# run integration tests for MariaDB (traditional SQL mode + interpolateParams)
+mariadb-traditional: export REFORM_TEST_DATABASE = mysql
+mariadb-traditional: export REFORM_TEST_DRIVER = mysql
+mariadb-traditional: export REFORM_TEST_ADMIN_SOURCE = root@tcp(localhost:6033)/mysql
+mariadb-traditional: export REFORM_TEST_INIT_SOURCE = root@tcp(localhost:6033)/reform-database?parseTime=true&clientFoundRows=true&time_zone='UTC'&sql_mode='ANSI'&multiStatements=true
+mariadb-traditional: export REFORM_TEST_SOURCE = root@tcp(localhost:6033)/reform-database?parseTime=true&clientFoundRows=true&time_zone='America%2FNew_York'&sql_mode='TRADITIONAL'&interpolateParams=true
+mariadb-traditional: export REFORM_TEST_COVER=mysql
+mariadb-traditional:
+	make test-db
+
+# run integration tests for MariaDB (ANSI SQL mode)
+mariadb: export REFORM_TEST_DATABASE = mysql
+mariadb: export REFORM_TEST_DRIVER = mysql
+mariadb: export REFORM_TEST_ADMIN_SOURCE = root@tcp(localhost:6033)/mysql
+mariadb: export REFORM_TEST_INIT_SOURCE = root@tcp(localhost:6033)/reform-database?parseTime=true&clientFoundRows=true&time_zone='UTC'&sql_mode='ANSI'&multiStatements=true
+mariadb: export REFORM_TEST_SOURCE = root@tcp(localhost:6033)/reform-database?parseTime=true&clientFoundRows=true&time_zone='America%2FNew_York'&sql_mode='ANSI'
+mariadb: export REFORM_TEST_COVER=mysql
+mariadb:
+	make test-db
+
+# run integration tests for MySQL (traditional SQL mode + interpolateParams)
+mysql-traditional: export REFORM_TEST_DATABASE = mysql
+mysql-traditional: export REFORM_TEST_DRIVER = mysql
+mysql-traditional: export REFORM_TEST_ADMIN_SOURCE = root@/mysql
+mysql-traditional: export REFORM_TEST_INIT_SOURCE = root@/reform-database?parseTime=true&clientFoundRows=true&time_zone='UTC'&sql_mode='ANSI'&multiStatements=true
+mysql-traditional: export REFORM_TEST_SOURCE = root@/reform-database?parseTime=true&clientFoundRows=true&time_zone='America%2FNew_York'&sql_mode='TRADITIONAL'&interpolateParams=true
+mysql-traditional: export REFORM_TEST_COVER=mysql-traditional
+mysql-traditional:
 	make test-db
 
 # run integration tests for MySQL (ANSI SQL mode)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,21 @@ services:
       timeout: 1s
       retries: 1
 
+  mariadb:
+    image: ${REFORM_MARIADB_IMAGE:-mariadb:10.5}
+    container_name: reform_mariadb
+    environment:
+      - TZ=Europe/Moscow
+      - MARIADB_ALLOW_EMPTY_ROOT_PASSWORD=1
+      - MARIADB_ROOT_HOST=%
+    ports:
+      - 127.0.0.1:6033:3306 # Would be otherwise in conflict with the mysql container
+    healthcheck:
+      test: echo 'SELECT 1' | mysql -P 6033
+      interval: 1s
+      timeout: 1s
+      retries: 1
+
   mssql:
     image: ${REFORM_MSSQL_IMAGE:-mcr.microsoft.com/mssql/server:2017-latest}
     container_name: reform_mssql


### PR DESCRIPTION
According to #257, MariaDB has been added to CI configuration. 
The minimal version taken of MariaDB is `10.2` as the `10.1` has an EOL on October 2020, thus this version is obsolete. 